### PR TITLE
Add tests for `SignedXml.CheckSignature` base on code review

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
@@ -6,8 +6,9 @@
 // Author:
 //  Atsushi Enomoto  <atsushi@ximian.com>
 //
-// Copyright (C) 2006 Novell, Inc (http://www.novell.com)using System.Collections;
+// Copyright (C) 2006 Novell, Inc (http://www.novell.com)
 
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;

--- a/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
@@ -1,4 +1,13 @@
-using System.Collections;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// EncryptedXmlTest.cs
+//
+// Author:
+//  Atsushi Enomoto  <atsushi@ximian.com>
+//
+// Copyright (C) 2006 Novell, Inc (http://www.novell.com)using System.Collections;
+
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;

--- a/src/libraries/System.Security.Cryptography.Xml/tests/EncryptionMethodTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/EncryptionMethodTest.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Security.Cryptography.Xml;
+using System.Xml;
+using Xunit;
+
+namespace System.Security.Cryptography.Xml.Tests
+{
+    public class EncryptionMethodTest
+    {
+        [Fact]
+        public void GetXml_ReturnsExpectedXml()
+        {
+            var encryptionMethod = new EncryptionMethod("http://www.w3.org/2001/04/xmlenc#aes256-cbc");
+            var xmlElement = encryptionMethod.GetXml();
+            Assert.Equal("<EncryptionMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#aes256-cbc\" />", xmlElement.OuterXml);
+        }
+
+        [Fact]
+        public void LoadXml_ValidXml_Success()
+        {
+            var xmlDocument = new XmlDocument();
+            xmlDocument.LoadXml("<EncryptionMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#aes256-cbc\" />");
+            var encryptionMethod = new EncryptionMethod();
+            encryptionMethod.LoadXml(xmlDocument.DocumentElement);
+            Assert.Equal("http://www.w3.org/2001/04/xmlenc#aes256-cbc", encryptionMethod.KeyAlgorithm);
+        }
+
+        [Fact]
+        public void LoadXml_InvalidXml_ThrowsException()
+        {
+            var xmlDocument = new XmlDocument();
+            xmlDocument.LoadXml("<InvalidXml></InvalidXml>");
+            var encryptionMethod = new EncryptionMethod();
+            Assert.Throws<XmlException>(() => encryptionMethod.LoadXml(xmlDocument.DocumentElement));
+        }
+
+        [Fact]
+        public void KeyAlgorithm_SetGet_ReturnsExpected()
+        {
+            var encryptionMethod = new EncryptionMethod();
+            encryptionMethod.KeyAlgorithm = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+            Assert.Equal("http://www.w3.org/2001/04/xmlenc#aes256-cbc", encryptionMethod.KeyAlgorithm);
+        }
+
+        [Fact]
+        public void KeySize_SetGet_ReturnsExpected()
+        {
+            var encryptionMethod = new EncryptionMethod();
+            encryptionMethod.KeySize = 256;
+            Assert.Equal(256, encryptionMethod.KeySize);
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SymmetricKeyWrapTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SymmetricKeyWrapTest.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Xml;
+using Xunit;
+
+namespace System.Security.Cryptography.Xml.Tests
+{
+    public class SymmetricKeyWrapTest
+    {
+        [Fact]
+        public void WrapKey_AES128()
+        {
+            using (Aes aes = Aes.Create())
+            {
+                aes.KeySize = 128;
+                byte[] keyToWrap = new byte[16];
+                byte[] wrappedKey = SymmetricKeyWrap.WrapKey(aes, keyToWrap);
+                byte[] unwrappedKey = SymmetricKeyWrap.UnwrapKey(aes, wrappedKey);
+                Assert.Equal(keyToWrap, unwrappedKey);
+            }
+        }
+
+        [Fact]
+        public void WrapKey_AES192()
+        {
+            using (Aes aes = Aes.Create())
+            {
+                aes.KeySize = 192;
+                byte[] keyToWrap = new byte[24];
+                byte[] wrappedKey = SymmetricKeyWrap.WrapKey(aes, keyToWrap);
+                byte[] unwrappedKey = SymmetricKeyWrap.UnwrapKey(aes, wrappedKey);
+                Assert.Equal(keyToWrap, unwrappedKey);
+            }
+        }
+
+        [Fact]
+        public void WrapKey_AES256()
+        {
+            using (Aes aes = Aes.Create())
+            {
+                aes.KeySize = 256;
+                byte[] keyToWrap = new byte[32];
+                byte[] wrappedKey = SymmetricKeyWrap.WrapKey(aes, keyToWrap);
+                byte[] unwrappedKey = SymmetricKeyWrap.UnwrapKey(aes, wrappedKey);
+                Assert.Equal(keyToWrap, unwrappedKey);
+            }
+        }
+
+        [Fact]
+        public void WrapKey_TripleDES()
+        {
+            using (TripleDES tripleDES = TripleDES.Create())
+            {
+                byte[] keyToWrap = new byte[24];
+                byte[] wrappedKey = SymmetricKeyWrap.WrapKey(tripleDES, keyToWrap);
+                byte[] unwrappedKey = SymmetricKeyWrap.UnwrapKey(tripleDES, wrappedKey);
+                Assert.Equal(keyToWrap, unwrappedKey);
+            }
+        }
+
+        [Fact]
+        public void WrapKey_InvalidAlgorithm()
+        {
+            using (SymmetricAlgorithm algorithm = new InvalidSymmetricAlgorithm())
+            {
+                byte[] keyToWrap = new byte[16];
+                Assert.Throws<CryptographicException>(() => SymmetricKeyWrap.WrapKey(algorithm, keyToWrap));
+            }
+        }
+
+        private class InvalidSymmetricAlgorithm : SymmetricAlgorithm
+        {
+            public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateIV()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void GenerateKey()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION

* **CheckSignature**: Add test for `CheckSignature` method with `X509Certificate2` and `verifySignatureOnly` parameter.
* **KeyInfoClause**: Add tests for `GetXml` and `LoadXml` methods.
* **CanonicalXmlEntityReference**: Add tests for `Write`, `WriteHash`, and `IsInNodeSet` methods.

Add `SymmetricKeyWrapTest.cs` to test `System.Security.Cryptography.Xml.SymmetricKeyWrap`.

Add `EncryptionMethodTest.cs` to test `System.Security.Cryptography.Xml.EncryptionMethod`.